### PR TITLE
Remove -universal

### DIFF
--- a/minecraft-forge/minecraft-forge-docker.json
+++ b/minecraft-forge/minecraft-forge-docker.json
@@ -30,7 +30,7 @@
           "target": "eula.txt"
         },
         {
-          "source": "forge-*-universal.jar",
+          "source": "forge-*.jar",
           "target": "server.jar",
           "type": "move"
         }

--- a/minecraft-forge/minecraft-forge.json
+++ b/minecraft-forge/minecraft-forge.json
@@ -30,7 +30,7 @@
           "target": "eula.txt"
         },
         {
-          "source": "forge-*-universal.jar",
+          "source": "forge-*.jar",
           "target": "server.jar",
           "type": "move"
         }


### PR DESCRIPTION
Later versions of forge do not prepend with `-universal` (1.14.4-28.0.23 for example) by removing the `-universal` and instead renaming any forge jar this works with all versions